### PR TITLE
認証メールのURL設定

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000}
 end


### PR DESCRIPTION
認証メールのURL設定
４１行目→  config.action_mailer.default_url_options = { host: 'localhost', port: 3000}