### PR TITLE
ログインしてない人が投稿できないようにした

### DIFF
--- a/app/controllers/examples_controller.rb
+++ b/app/controllers/examples_controller.rb
@@ -1,5 +1,5 @@
 class ExamplesController < ApplicationController
-  before_action :set_example, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, except: :index
 
   # GET /examples
   # GET /examples.json
@@ -63,8 +63,8 @@ class ExamplesController < ApplicationController
 
   private
     # Use callbacks to share common setup or constraints between actions.
-    def set_example
-      @example = Example.find(params[:id])
+    def move_to_index
+      redirect_to action: :index unless user_signed_in?
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.


### PR DESCRIPTION
examplesのコントローラーに、before_action :move_to_index, except: :index　を設定した。